### PR TITLE
Update dependency for CVE-2018-16471

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org/'
 gem "sinatra", ">= 2.0.2"
 gem 'sinatra-contrib'
 gem 'minitest'
+gem "rack", ">= 2.0.6"
 gem 'rack-test'
 gem 'rake'
 gem 'minitest-ci'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,43 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.8.0)
+    activesupport (5.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    backports (3.11.4)
+    concurrent-ruby (1.1.3)
+    i18n (1.2.0)
+      concurrent-ruby (~> 1.0)
     minitest (5.10.2)
     minitest-ci (3.2.0)
       minitest (>= 5.0.6)
-    multi_json (1.12.1)
-    mustermann (1.0.0)
-    rack (2.0.3)
-    rack-protection (2.0.0)
+    multi_json (1.13.1)
+    mustermann (1.0.3)
+    rack (2.0.6)
+    rack-protection (2.0.4)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rake (12.0.0)
-    sinatra (2.0.0)
+    sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.4)
       tilt (~> 2.0)
-    sinatra-contrib (2.0.0)
-      backports (>= 2.0)
+    sinatra-contrib (2.0.4)
+      activesupport (>= 4.0.0)
+      backports (>= 2.8.2)
       multi_json
       mustermann (~> 1.0)
-      rack-protection (= 2.0.0)
-      sinatra (= 2.0.0)
+      rack-protection (= 2.0.4)
+      sinatra (= 2.0.4)
       tilt (>= 1.3, < 3)
-    tilt (2.0.7)
+    thread_safe (0.3.6)
+    tilt (2.0.9)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -33,10 +45,11 @@ PLATFORMS
 DEPENDENCIES
   minitest
   minitest-ci
+  rack (>= 2.0.6)
   rack-test
   rake
-  sinatra
+  sinatra (>= 2.0.2)
   sinatra-contrib
 
 BUNDLED WITH
-   1.15.1
+   1.17.2


### PR DESCRIPTION
Fixes issue #6 for CVE-2018-16471
There is a possible XSS vulnerability in Rack before 2.0.6 and 1.6.11. Carefully crafted requests can impact the data returned by the scheme method on Rack::Request. Applications that expect the scheme to be limited to 'http' or 'https' and do not escape the return value could be vulnerable to an XSS attack. Note that applications using the normal escaping mechanisms provided by Rails may not impacted, but applications that bypass the escaping mechanisms, or do not use them may be vulnerable.